### PR TITLE
Add ICP product landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Test Codex on ICP
+
+This repository contains a simple landing page introducing key products of the Internet Computer Protocol (ICP) and highlighting community open-source projects.
+
+## Open Source ICP Projects
+
+- [Motoko](https://github.com/dfinity/motoko)
+- [Internet Identity](https://github.com/dfinity/internet-identity)
+- [nns-dapp](https://github.com/dfinity/nns-dapp)
+- [ic-js](https://github.com/dfinity/ic-js)
+- [ic](https://github.com/dfinity/ic)
+
+Open `index.html` in a browser to explore the page.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ICP Products</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Internet Computer Protocol</h1>
+    <nav>
+      <a href="#products">Products</a>
+      <a href="#projects">Open Source Projects</a>
+    </nav>
+  </header>
+
+  <section class="hero">
+    <h2>Build on the Open Internet</h2>
+    <p>The Internet Computer Protocol (ICP) empowers developers to build scalable, secure, and open web services.</p>
+  </section>
+
+  <section id="products">
+    <h2>ICP Products</h2>
+    <div class="product-grid">
+      <div class="product">
+        <h3>Internet Identity</h3>
+        <p>Privacy-preserving authentication system for web3.</p>
+      </div>
+      <div class="product">
+        <h3>Motoko</h3>
+        <p>A language designed for building canister smart contracts.</p>
+      </div>
+      <div class="product">
+        <h3>Canister SDK (DFX)</h3>
+        <p>Developer tools for creating and deploying canisters.</p>
+      </div>
+      <div class="product">
+        <h3>Cycles Wallet</h3>
+        <p>Manage cycles for powering your canisters.</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="projects">
+    <h2>Open Source ICP Projects</h2>
+    <ul id="project-list"></ul>
+  </section>
+
+  <footer>
+    <p>Built with ❤️ for the Internet Computer community.</p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,18 @@
+const projects = [
+  { name: 'Motoko', url: 'https://github.com/dfinity/motoko' },
+  { name: 'Internet Identity', url: 'https://github.com/dfinity/internet-identity' },
+  { name: 'nns-dapp', url: 'https://github.com/dfinity/nns-dapp' },
+  { name: 'ic-js', url: 'https://github.com/dfinity/ic-js' },
+  { name: 'ic', url: 'https://github.com/dfinity/ic' }
+];
+
+const list = document.getElementById('project-list');
+projects.forEach((p) => {
+  const li = document.createElement('li');
+  const link = document.createElement('a');
+  link.href = p.url;
+  link.textContent = p.name;
+  link.target = '_blank';
+  li.appendChild(link);
+  list.appendChild(li);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,48 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  line-height: 1.6;
+  color: #333;
+}
+
+header {
+  background: #00246c;
+  color: #fff;
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+nav a {
+  color: #fff;
+  margin-left: 1rem;
+  text-decoration: none;
+}
+
+.hero {
+  background: #f5f5f5;
+  padding: 2rem;
+  text-align: center;
+}
+
+.product-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.product {
+  background: #e8eaf6;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #00246c;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add HTML landing page highlighting ICP products
- style page with basic CSS and populate open source project list with JS
- document featured ICP open source projects in README

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a491f7b66c8325a7b5ccc84b187f51